### PR TITLE
Penalty reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ int32 away_bot_count        #
 int32 remaining_seconds     # how many more seconds are remaining in this half?
 bool play                   # Play/Pause -- robots should freeze in place when false
 bool reset_field            # Robots should go to their home positions and freeze while true
+bool home_penalty           # If reset_field is true and my team (home/away) receives a penalty,
+bool away_penalty           #   then this will be true and my team should reset to penalty mode
 bool second_half            # Second half of match. Robots should switch sides.
 ```
 

--- a/msg/GameState.msg
+++ b/msg/GameState.msg
@@ -5,4 +5,6 @@ int32 away_bot_count
 int32 remaining_seconds
 bool play
 bool reset_field
+bool home_penalty
+bool away_penalty
 bool second_half

--- a/nodes/referee/Referee.py
+++ b/nodes/referee/Referee.py
@@ -303,6 +303,10 @@ class Referee(object):
             # We don't need to reset the field anymore
             self.game_state.reset_field = False
 
+            # we can also clear any penalties
+            self.game_state.home_penalty = False
+            self.game_state.away_penalty = False
+
             # Update the UI
             self.ui.btn_play.setText('Pause')
 
@@ -404,4 +408,9 @@ class Referee(object):
 
 
     def _handle_penalty(self, home=True):
-        pass
+        # reset the field
+        self._btn_reset_field()
+
+        # let the team know they need to reset in penalty mode
+        self.game_state.home_penalty = home
+        self.game_state.away_penalty = not home

--- a/nodes/referee/Referee.py
+++ b/nodes/referee/Referee.py
@@ -32,6 +32,8 @@ class RefereeUI(object):
         self.btn_next_half = ui.btnNextHalf
         self.btn_reset_clock = ui.btnResetClock
         self.btn_start_game = ui.btnStartGame
+        self.btn_home_penalty = ui.btnHomePenalty
+        self.btn_away_penalty = ui.btnAwayPenalty
 
         # Score +/- buttons
         self.btn_home_inc_score = ui.btngoal_inc_home
@@ -164,6 +166,9 @@ class RefereeUI(object):
         self.btn_next_half.setEnabled(enable)
         self.btn_reset_clock.setEnabled(enable)
 
+        self.btn_home_penalty.setEnabled(enable)
+        self.btn_away_penalty.setEnabled(enable)
+
         self.btn_home_inc_score.setEnabled(enable)
         self.btn_home_dec_score.setEnabled(enable)
         self.btn_away_inc_score.setEnabled(enable)
@@ -205,6 +210,10 @@ class Referee(object):
         self.ui.btn_next_half.clicked.connect(self._btn_next_half)
         self.ui.btn_reset_clock.clicked.connect(self._btn_reset_clock)
         self.ui.btn_start_game.clicked.connect(self._btn_start_game)
+
+        # Penalty buttons
+        self.ui.btn_home_penalty.clicked.connect(lambda: self._handle_penalty(home=False))
+        self.ui.btn_away_penalty.clicked.connect(lambda: self._handle_penalty(home=False))
 
         # Score +/- buttons
         self.ui.btn_home_inc_score.clicked.connect(lambda: self._handle_score(home=True, inc=True))
@@ -392,3 +401,7 @@ class Referee(object):
 
         # update the score UI
         self.ui.update_scores(self.game_state.home_score, self.game_state.away_score)
+
+
+    def _handle_penalty(self, home=True):
+        pass

--- a/nodes/referee/Referee.py
+++ b/nodes/referee/Referee.py
@@ -212,7 +212,7 @@ class Referee(object):
         self.ui.btn_start_game.clicked.connect(self._btn_start_game)
 
         # Penalty buttons
-        self.ui.btn_home_penalty.clicked.connect(lambda: self._handle_penalty(home=False))
+        self.ui.btn_home_penalty.clicked.connect(lambda: self._handle_penalty(home=True))
         self.ui.btn_away_penalty.clicked.connect(lambda: self._handle_penalty(home=False))
 
         # Score +/- buttons

--- a/nodes/referee/window.ui
+++ b/nodes/referee/window.ui
@@ -1317,6 +1317,48 @@
      <string/>
     </property>
    </widget>
+   <widget class="QPushButton" name="btnHomePenalty">
+    <property name="enabled">
+     <bool>false</bool>
+    </property>
+    <property name="geometry">
+     <rect>
+      <x>93</x>
+      <y>220</y>
+      <width>111</width>
+      <height>41</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>12</pointsize>
+     </font>
+    </property>
+    <property name="text">
+     <string>Penalty</string>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="btnAwayPenalty">
+    <property name="enabled">
+     <bool>false</bool>
+    </property>
+    <property name="geometry">
+     <rect>
+      <x>514</x>
+      <y>220</y>
+      <width>111</width>
+      <height>41</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>12</pointsize>
+     </font>
+    </property>
+    <property name="text">
+     <string>Penalty</string>
+    </property>
+   </widget>
   </widget>
   <widget class="QMenuBar" name="menubar">
    <property name="geometry">


### PR DESCRIPTION
Added two `Penalty` buttons -- one for each side. In the event of a penalty, the culprit's button should be pressed, causing that team to reset into the penalty state as defined in the [Robot Soccer 2017 Rules](http://rwbclasses.groups.et.byu.net/lib/exe/fetch.php?media=robot_soccer:material:robot_soccer_rules.pdf), under *Operation*.

This effectively sends the `Reset Field` command, with extra information as to which side is in penalty mode (home/away). The `GameState` message was modified to support this.

![image](https://cloud.githubusercontent.com/assets/3934603/24102583/1441fe3c-0d42-11e7-897a-cfa2c91293fb.png)

This fixes #5 
