### PR TITLE
Reset after goal

### DIFF
--- a/nodes/referee/Referee.py
+++ b/nodes/referee/Referee.py
@@ -1,5 +1,7 @@
 from PyQt4 import QtGui, QtCore
 
+import math
+
 import rospy, rostopic
 from soccerref.msg import GameState
 from geometry_msgs.msg import Pose2D
@@ -111,7 +113,7 @@ class RefereeUI(object):
 
     def get_timer_seconds(self):
         ms = self.game_timer['milliseconds']
-        return ms/1000
+        return int(math.ceil(ms/1000.0))
 
     def update_timer_ui(self):
         ms = self.game_timer['milliseconds']

--- a/nodes/referee/Referee.py
+++ b/nodes/referee/Referee.py
@@ -260,14 +260,9 @@ class Referee(object):
             self.ballIsStillInGoal = True
 
             # Now lets decide who gets the point, based off home/away and which half we are on
-            if home_side ^ self.game_state.second_half:
-                self.game_state.away_score += 1
-
-            elif away_side ^ self.game_state.second_half:
-                self.game_state.home_score += 1
-
-            # Update UI
-            self.ui.update_scores(self.game_state.home_score, self.game_state.away_score)
+            home = away_side ^ self.game_state.second_half
+            inc = True
+            self._handle_score(home=home, inc=inc)
 
         # If last we knew, the ball was in the goal but now it's not, update that
         if self.ballIsStillInGoal and abs(msg.x) < out_of_goal_threshold:
@@ -384,6 +379,9 @@ class Referee(object):
                 
 
     def _handle_score(self, home=True, inc=True):
+        # reset the field
+        self._btn_reset_field()
+
         # update the global state
         if home:
             self.game_state.home_score += 1 if inc else -1


### PR DESCRIPTION
Routed all score changing code through the same function. Whenever the score is changed on either team (inc or dec) the field is reset and the clocked stop until the `Play` button is pressed.

Also fixes an off-by-one error where the published `remaining_seconds` topic reported 1 second less than the referee timer display.

Fixes #3 