### PR TITLE
Add vision node

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(soccerref)
+add_definitions(-std=c++11)
 
 # Find catkin and any catkin packages
 find_package(catkin REQUIRED COMPONENTS 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ find_package(catkin REQUIRED COMPONENTS
     std_msgs
     geometry_msgs
     message_generation
+    image_transport
+    sensor_msgs
+    cv_bridge
 )
 
 # Declare ROS messages
@@ -18,3 +21,11 @@ generate_messages(DEPENDENCIES std_msgs geometry_msgs)
 
 # Declare a catkin package
 catkin_package(CATKIN_DEPENDS roscpp rospy std_msgs geometry_msgs message_runtime)
+
+# Specify additional locations of header files
+include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS} ${GAZEBO_INCLUDE_DIRS})
+
+# Declare C++ executables
+add_executable(soccerref_vision src/vision.cpp)
+find_package( OpenCV REQUIRED )
+target_link_libraries(soccerref_vision ${OpenCV_LIBS} ${catkin_LIBRARIES})

--- a/launch/referee.launch
+++ b/launch/referee.launch
@@ -6,7 +6,9 @@
     <arg name="use_timer" default="true" />
     <arg name="simulation_mode" default="false" />
     <arg name="competition_mode" default="false" />
+    <arg name="camera" default="home" />
 
+    <!-- referee -->
     <node name="referee" pkg="soccerref" type="referee_node.py" output="screen">
         <param name="half_duration_secs" type="int" value="$(arg half_duration_secs)" />
         <param name="use_timer" type="bool" value="$(arg use_timer)" />
@@ -14,4 +16,10 @@
         <param name="competition_mode" type="bool" value="$(arg competition_mode)" />
     </node>
 
+    <!-- vision (only if not in simulation mode) -->
+    <group unless="$(arg simulation_mode)">
+        <node name="soccerref_vision" pkg="soccerref" type="soccerref_vision" output="screen">
+            <remap from="/camera1/image_raw" to="/usb_cam_$(arg camera)/image_raw" />
+        </node>
+    </group>
 </launch>

--- a/nodes/referee/Referee.py
+++ b/nodes/referee/Referee.py
@@ -180,7 +180,7 @@ class Referee(object):
         self.ui = RefereeUI(ui, sim_mode, use_timer, competition_mode)
 
         # Connect to ROS things
-        ball_topic = '/ball/truth' if sim_mode else '/vision/ball' # TODO: Create a ref-vision node?
+        ball_topic = '/ball/truth' if sim_mode else '/vision/ball'
         rospy.Subscriber(ball_topic, Pose2D, self._handle_vision_ball)
         
         self.pub_game_state = rospy.Publisher('game_state', GameState, queue_size=10, latch=True)

--- a/src/vision.cpp
+++ b/src/vision.cpp
@@ -90,25 +90,21 @@ void getBallPose(Mat& imgHsv, Scalar color[], geometry_msgs::Pose2D& ballPose)
 	if (hierarchy.size() < 1)
 		return;
 
+	// Sort
+	vector<Moments> mm;
 	for(int i = 0; i < hierarchy.size(); i++)
 		mm.push_back(moments((Mat)contours[i]));
-
 	std::sort(mm.begin(), mm.end(), compareMomentAreas);
 
-	Moments mm = moments((Mat)contours[0]);
-	Point2d ballCenter = imageToWorldCoordinates(getCenterOfMass(mm));
-
+	// Use largest to calculate ball center
+	Point2d ballCenter = imageToWorldCoordinates(getCenterOfMass(mm[0]));
 	ballPose.x = ballCenter.x;
 	ballPose.y = ballCenter.y;
 	ballPose.theta = 0;
 }
 
-void processImage(Mat img)
+void processImage(Mat img, Mat hsv)
 {
-	// Convert to HSV
-	Mat imgHsv;
-	cvtColor(img, hsv, COLOR_BGR2HSV);
-
 	// Threshold, etc
 	getBallPose(hsv,  yellow, poseBall);
 
@@ -116,31 +112,158 @@ void processImage(Mat img)
 	ball_pub.publish(poseBall);
 }
 
+void channelDist(Mat& hsv, Mat& dist, int hueVal, int channel)
+{
+	Mat hue;
+	extractChannel(hsv, hue, channel);
+	if (channel == 0)
+	{
+		Mat dist1, dist2;
+		absdiff(hue, hueVal, dist1);
+		absdiff(hue, hueVal + ((hueVal < 90) ? 180 : -180), dist2);
+		min(dist1, dist2, dist);
+	}
+	else
+		absdiff(hue, hueVal, dist);
+}
+
+void hueMax(Mat& hsv, Mat& img)
+{
+	vector<Mat> channels;
+	split(hsv, channels);
+	channels[1].setTo(255);
+	channels[2].setTo(255);
+	Mat hsv2;
+	merge(channels, hsv2);
+	cvtColor(hsv2, img, CV_HSV2BGR);
+}
+
+void detectLines(Mat& img)
+{
+	// Init
+	static Ptr<LineSegmentDetector> ls = createLineSegmentDetector(LSD_REFINE_STD); //can use LSD_REFINE_STD or LSD_REFINE_NONE
+
+	// Convert to grayscale
+    Mat gray;
+    cvtColor(img, gray, COLOR_BGR2GRAY);
+
+    // Detect the lines
+    vector<Vec4f> lines_std;
+    ls->detect(gray, lines_std);
+
+    // Show found lines
+    ls->drawSegments(img, lines_std);
+}
+
+void showHistogram(Mat& img)
+{
+	int bins = 256;             // number of bins
+	int nc = img.channels();    // number of channels
+
+	vector<Mat> hist(nc);       // histogram arrays
+
+	// Initalize histogram arrays
+	for (int i = 0; i < hist.size(); i++)
+		hist[i] = Mat::zeros(1, bins, CV_32SC1);
+
+	// Calculate the histogram of the image
+	for (int i = 0; i < img.rows; i++)
+	{
+		for (int j = 0; j < img.cols; j++)
+		{
+			for (int k = 0; k < nc; k++)
+			{
+				uchar val = nc == 1 ? img.at<uchar>(i,j) : img.at<Vec3b>(i,j)[k];
+				hist[k].at<int>(val) += 1;
+			}
+		}
+	}
+
+	// For each histogram arrays, obtain the maximum (peak) value
+	// Needed to normalize the display later
+	int hmax[3] = {0,0,0};
+	for (int i = 0; i < nc; i++)
+	{
+		for (int j = 0; j < bins-1; j++)
+			hmax[i] = hist[i].at<int>(j) > hmax[i] ? hist[i].at<int>(j) : hmax[i];
+	}
+
+	//const char* wname[3] = { "blue", "green", "red" };
+	//Scalar colors[3] = { Scalar(255,0,0), Scalar(0,255,0), Scalar(0,0,255) };
+	const char* wname[3] = { "hue", "sat", "val" };
+	Scalar colors[3] = { Scalar(255,255,255), Scalar(255,255,255), Scalar(255,255,255) };
+
+	vector<Mat> canvas(nc);
+
+	// Display each histogram in a canvas
+	for (int i = 0; i < nc; i++)
+	{
+		canvas[i] = Mat::ones(125, bins, CV_8UC3);
+
+		for (int j = 0, rows = canvas[i].rows; j < bins-1; j++)
+		{
+			line(
+				canvas[i], 
+				Point(j, rows), 
+				Point(j, rows - (hist[i].at<int>(j) * rows/hmax[i])), 
+				nc == 1 ? Scalar(200,200,200) : colors[i], 
+				1, 8, 0
+			);
+		}
+		imshow(nc == 1 ? "value" : wname[i], canvas[i]);
+	}
+}
+
+char lastKeyPressed;
+int hueVal = 0;
+Mat hsv, img, bgr;
+
 void imageCallback(const sensor_msgs::ImageConstPtr& msg)
 {
-	try
-	{
-		Mat frame = cv_bridge::toCvShare(msg, "bgr8")->image;
-		processImage(frame);
-		imshow(GUI_NAME, frame);
-		waitKey(30);
-	}
-	catch (cv_bridge::Exception& e)
-	{
-		ROS_ERROR("Could not convert from '%s' to 'bgr8'.", msg->encoding.c_str());
-	}
+	bgr = cv_bridge::toCvShare(msg, "bgr8")->image;
+	img = bgr;
+	cvtColor(img, hsv, COLOR_BGR2HSV);
+	processImage(img, hsv);
+
+	if(lastKeyPressed == 'h')
+		extractChannel(hsv, img, 0);
+	if(lastKeyPressed == 'i')
+		hueMax(hsv, img);
+	if(lastKeyPressed == 's')
+		extractChannel(hsv, img, 1);
+	if(lastKeyPressed == 'v')
+		extractChannel(hsv, img, 2);
+	if(lastKeyPressed == 'd')
+		channelDist(hsv, img, hueVal, 0);
+	if(lastKeyPressed == 'a')
+		img = hsv;
+	if(lastKeyPressed == 'l')
+		detectLines(img);
+	if(lastKeyPressed == 't')
+		showHistogram(hsv);
+
+	imshow(GUI_NAME, img);
+
+	// Wait for key press
+	char key = waitKey(30);
+	if(key != -1)
+		lastKeyPressed = key;
+	if(key == 'q')
+		ros::shutdown();
 }
 
 void mouseCallback(int event, int x, int y, int flags, void* userdata)
 {
+	Vec3b bgrVal = bgr.at<Vec3b>(y, x);
+	Vec3b hsvVal = hsv.at<Vec3b>(y, x);
+	char buffer[100];
+	sprintf(buffer, "B:%d G:%d R:%d - H:%d S:%d V:%d", bgrVal[0], bgrVal[1], bgrVal[2], hsvVal[0], hsvVal[1], hsvVal[2]);
+	displayStatusBar(GUI_NAME, buffer, 10000);
+
 	if (event == EVENT_LBUTTONDOWN)
-	{
-		mouse_left_down = true;
-		Point2d point_meters = imageToWorldCoordinates(Point2d(x, y));
-		char buffer[50];
-		sprintf(buffer, "Location: (%.3f m, %.3f m)", point_meters.x, point_meters.y);
-		displayStatusBar(GUI_NAME, buffer, 10000);
-	}
+		hueVal = hsvVal[0];
+	// Point2d point_meters = imageToWorldCoordinates(Point2d(x, y));
+	//sprintf(buffer, "Location: (%.3f m, %.3f m)", point_meters.x, point_meters.y);
 }
 
 int main(int argc, char **argv)

--- a/src/vision.cpp
+++ b/src/vision.cpp
@@ -397,8 +397,29 @@ void moveClosestPoint(Point clickPoint)
 void drawPoints(Mat img)
 {
 	const Point* ppt[1] = { &points[0] };
-	int npt[] = { points.size() };	
-	fillPoly(img, ppt, npt, 1, Scalar(255, 255, 255), CV_AA);
+	int npt[] = { points.size() };
+	Mat mask = Mat(img.size(), CV_8UC1, Scalar(0));
+	fillPoly(mask, ppt, npt, 1, Scalar(255), CV_AA);
+	//Mat drawing = img.clone();
+	Mat drawing = Mat(img.size(), CV_8UC3, Scalar(0));
+	img.copyTo(drawing, mask);
+	addWeighted(img, .5, drawing, .5, 0, img);
+	vector<Point2f> pts_image = vector<Point2f>(points.size());
+	for(int i = 0; i < points.size(); i++)
+		pts_image[i] = Point2f(points[i]);
+		
+	vector<Point2f> pts_world = vector<Point2f>(points.size());
+	pts_world[0] = Point2f(-FIELD_WIDTH/2, -FIELD_HEIGHT/2);
+	pts_world[1] = Point2f(FIELD_WIDTH/2, -FIELD_HEIGHT/2);
+	pts_world[2] = Point2f(FIELD_WIDTH/2, FIELD_HEIGHT/2);
+	pts_world[3] = Point2f(-FIELD_WIDTH/2, FIELD_HEIGHT/2);
+	
+	//Mat H = findHomography()
+	Mat H = getPerspectiveTransform(pts_image, pts_world);
+	vector<Point2f> test;
+	perspectiveTransform(pts_image, test, H);
+	for(int i = 0; i < points.size(); i++)
+		printf("%d - %f, %f\n", i, test[i].x, test[i].y);
 }
 
 int mouseDown;

--- a/src/vision.cpp
+++ b/src/vision.cpp
@@ -1,0 +1,251 @@
+#include "ros/ros.h"
+#include "geometry_msgs/Pose2D.h"
+#include "geometry_msgs/Vector3.h"
+#include <image_transport/image_transport.h>
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+#include <cv_bridge/cv_bridge.h>
+
+#include <cmath>
+#include <iostream>
+#include <cv.h>
+#include <highgui.h>
+
+using namespace std;
+using namespace cv;
+
+#define FIELD_WIDTH     3.53  // in meters
+#define FIELD_HEIGHT    2.39 
+#define ROBOT_RADIUS    0.10
+#define GUI_NAME        "Soccer Overhead Camera"
+
+// Mouse click parameters, empirically found
+// The smaller the number, the more positive the error
+// (i.e., it will be above the mouse in +y region)
+#define FIELD_WIDTH_PIXELS      577.0 // measured from threshold of goal to goal
+#define FIELD_HEIGHT_PIXELS     388.0 // measured from inside of wall to wall
+#define CAMERA_WIDTH            640.0
+#define CAMERA_HEIGHT           480.0
+
+// These colours need to match the Gazebo materials
+Scalar red[]    = {Scalar(0,   128, 128), Scalar(10,  255, 255)};
+Scalar yellow[] = {Scalar(20,  128, 128), Scalar(30,  255, 255)};
+Scalar green[]  = {Scalar(55,  128, 128), Scalar(65,  255, 255)};
+Scalar blue[]   = {Scalar(115, 128, 128), Scalar(125, 255, 255)};
+Scalar purple[] = {Scalar(145, 128, 128), Scalar(155, 255, 255)};
+
+// Handlers for vision position publishers
+ros::Publisher home1_pub;
+ros::Publisher home2_pub;
+ros::Publisher away1_pub;
+ros::Publisher away2_pub;
+ros::Publisher ball_pub;
+ros::Publisher ball_position_pub; // for publishing internally from the vision window
+
+// Use variables to store position of objects. These variables are very
+// useful when the ball cannot be seen, otherwise we'll get the position (0, 0)
+geometry_msgs::Pose2D poseHome1;
+geometry_msgs::Pose2D poseHome2;
+geometry_msgs::Pose2D poseAway1;
+geometry_msgs::Pose2D poseAway2;
+geometry_msgs::Pose2D poseBall;
+
+void thresholdImage(Mat& imgHSV, Mat& imgGray, Scalar color[])
+{
+	inRange(imgHSV, color[0], color[1], imgGray);
+
+	erode(imgGray, imgGray, getStructuringElement(MORPH_ELLIPSE, Size(2, 2)));
+	dilate(imgGray, imgGray, getStructuringElement(MORPH_ELLIPSE, Size(2, 2)));
+}
+
+Point2d getCenterOfMass(Moments moment)
+{
+	double m10 = moment.m10;
+	double m01 = moment.m01;
+	double mass = moment.m00;
+	double x = m10 / mass;
+	double y = m01 / mass;
+	return Point2d(x, y);
+}
+
+bool compareMomentAreas(Moments moment1, Moments moment2)
+{
+	double area1 = moment1.m00;
+	double area2 = moment2.m00;
+	return area1 < area2;
+}
+
+Point2d imageToWorldCoordinates(Point2d point_i)
+{
+	Point2d centerOfField(CAMERA_WIDTH/2, CAMERA_HEIGHT/2);
+	Point2d center_w = (point_i - centerOfField);
+
+	// You have to split up the pixel to meter conversion
+	// because it is a rect, not a square!
+	center_w.x *= (FIELD_WIDTH/FIELD_WIDTH_PIXELS);
+	center_w.y *= (FIELD_HEIGHT/FIELD_HEIGHT_PIXELS);
+
+	// Reflect y
+	center_w.y = -center_w.y;
+	
+	return center_w;
+}
+
+void getRobotPose(Mat& imgHsv, Scalar color[], geometry_msgs::Pose2D& robotPose)
+{
+	Mat imgGray;
+	thresholdImage(imgHsv, imgGray, color);
+
+	vector< vector<Point> > contours;
+	vector<Moments> mm;
+	vector<Vec4i> hierarchy;
+	findContours(imgGray, contours, hierarchy, CV_RETR_CCOMP, CV_CHAIN_APPROX_SIMPLE);
+
+	if (hierarchy.size() != 2)
+		return;
+
+	for(int i = 0; i < hierarchy.size(); i++)
+		mm.push_back(moments((Mat)contours[i]));
+
+	std::sort(mm.begin(), mm.end(), compareMomentAreas);
+	Moments mmLarge = mm[mm.size() - 1];
+	Moments mmSmall = mm[mm.size() - 2];
+
+	Point2d centerLarge = imageToWorldCoordinates(getCenterOfMass(mmLarge));
+	Point2d centerSmall = imageToWorldCoordinates(getCenterOfMass(mmSmall));
+
+	Point2d robotCenter = (centerLarge + centerSmall) * (1.0 / 2);
+	Point2d diff = centerSmall - centerLarge;
+	double angle = atan2(diff.y, diff.x);
+
+	//convert angle to degrees
+	angle = angle *180/M_PI;
+	robotPose.x = robotCenter.x;
+	robotPose.y = robotCenter.y;
+	robotPose.theta = angle;
+}
+
+void getBallPose(Mat& imgHsv, Scalar color[], geometry_msgs::Pose2D& ballPose)
+{
+	Mat imgGray;
+	thresholdImage(imgHsv, imgGray, color);
+
+	vector< vector<Point> > contours;
+	vector<Vec4i> hierarchy;
+	findContours(imgGray, contours, hierarchy, CV_RETR_CCOMP, CV_CHAIN_APPROX_SIMPLE);
+
+	if (hierarchy.size() != 1)
+		return;
+
+	Moments mm = moments((Mat)contours[0]);
+	Point2d ballCenter = imageToWorldCoordinates(getCenterOfMass(mm));
+
+	ballPose.x = ballCenter.x;
+	ballPose.y = ballCenter.y;
+	ballPose.theta = 0;
+}
+
+void processImage(Mat frame)
+{
+	Mat imgHsv;
+	cvtColor(frame, imgHsv, COLOR_BGR2HSV);
+
+	getRobotPose(imgHsv, blue,   poseHome1);
+	getRobotPose(imgHsv, green,  poseHome2);
+	getRobotPose(imgHsv, red,    poseAway1);
+	getRobotPose(imgHsv, purple, poseAway2);
+	getBallPose(imgHsv,  yellow, poseBall);
+
+	home1_pub.publish(poseHome1);
+	home2_pub.publish(poseHome2);
+	away1_pub.publish(poseAway1);
+	away2_pub.publish(poseAway2);
+	ball_pub.publish(poseBall);
+}
+
+void imageCallback(const sensor_msgs::ImageConstPtr& msg)
+{
+	try
+	{
+		Mat frame = cv_bridge::toCvShare(msg, "bgr8")->image;
+		processImage(frame);
+		imshow(GUI_NAME, frame);
+		waitKey(30);
+	}
+	catch (cv_bridge::Exception& e)
+	{
+		ROS_ERROR("Could not convert from '%s' to 'bgr8'.", msg->encoding.c_str());
+	}
+}
+
+void sendBallMessage(int x, int y) {
+	// Expects x, y in pixels
+
+	// Convert pixels to meters for sending  simulated ball position from mouse clicks
+	float x_meters, y_meters;
+
+	// shift data by half the pixels so (0, 0) is in center
+	x_meters = x - (CAMERA_WIDTH/2.0);   
+	y_meters = y - (CAMERA_HEIGHT/2.0);
+
+	// Multiply by aspect-ratio scaling factor
+	x_meters = x_meters * (FIELD_WIDTH/FIELD_WIDTH_PIXELS);
+	y_meters = y_meters * (FIELD_HEIGHT/FIELD_HEIGHT_PIXELS);
+
+	// mirror y over y-axis
+	y_meters = -1*y_meters;
+
+	// cout << "x: " << x_meters << ", y: " << y_meters << endl;
+
+	geometry_msgs::Vector3 msg;
+	msg.x = x_meters;
+	msg.y = y_meters;
+	msg.z = 0;
+	ball_position_pub.publish(msg);
+}
+
+void mouseCallback(int event, int x, int y, int flags, void* userdata) {
+	static bool mouse_left_down = false;
+
+	if (event == EVENT_LBUTTONDOWN) {
+		mouse_left_down = true;
+		Point2d point_meters = imageToWorldCoordinates(Point2d(x, y));
+		char buffer[50];
+		sprintf(buffer, "Location: (%.3f m, %.3f m)", point_meters.x, point_meters.y);
+		displayStatusBar(GUI_NAME, buffer, 10000);
+
+	} else if (event == EVENT_MOUSEMOVE) {
+		if (mouse_left_down) sendBallMessage(x, y);
+
+	} else if (event == EVENT_LBUTTONUP) {
+		sendBallMessage(x, y);
+		mouse_left_down = false;
+	}
+	
+}
+
+int main(int argc, char **argv)
+{
+	ros::init(argc, argv, "vision_sim");
+	ros::NodeHandle nh;
+
+	// Create OpenCV Window and add a mouse callback for clicking
+	namedWindow(GUI_NAME, CV_WINDOW_AUTOSIZE);
+	setMouseCallback(GUI_NAME, mouseCallback, NULL);
+
+	// Create ball publisher
+	ball_position_pub = nh.advertise<geometry_msgs::Vector3>("/ball/command", 1);
+
+	// Subscribe to camera
+	image_transport::ImageTransport it(nh);
+	image_transport::Subscriber image_sub = it.subscribe("/camera1/image_raw", 1, imageCallback);
+
+	// Create Vision Publishers
+	home1_pub = nh.advertise<geometry_msgs::Pose2D>("/vision/home1", 5);
+	home2_pub = nh.advertise<geometry_msgs::Pose2D>("/vision/home2", 5);
+	away1_pub = nh.advertise<geometry_msgs::Pose2D>("/vision/away1", 5);
+	away2_pub = nh.advertise<geometry_msgs::Pose2D>("/vision/away2", 5);
+	ball_pub = nh.advertise<geometry_msgs::Pose2D>("/vision/ball", 5);
+	ros::spin();
+	return 0;
+}


### PR DESCRIPTION
Add vision node to referee, allowing referee to determine if a goal was scored. Features include
- HSV color thresholding
- Mask to prevent objects outside of field from being detected
- Perspective transform to accurately calculate location of ball
- Publishes ball location
- Loads and saves hsv thresholds and field corners using rosparam API

Fixes #1 

![screenshot from 2017-03-21 21-21-17](https://cloud.githubusercontent.com/assets/11321258/24181157/d89c0f42-0e7e-11e7-832d-d386cd99b59b.png)

![screenshot from 2017-03-21 21-33-32](https://cloud.githubusercontent.com/assets/11321258/24181167/e2bd6ad4-0e7e-11e7-8d64-71b187d59dbc.png)